### PR TITLE
Adds push errors header to umbrella header

### DIFF
--- a/PCFPush/PCFPush.h
+++ b/PCFPush/PCFPush.h
@@ -4,6 +4,7 @@
 
 #import <UIKit/UIKit.h>
 #import "PCFPushGeofenceStatus.h"
+#import "PCFPushErrors.h"
 
 /**
  * Primary entry point for the PCF Push Client SDK library.


### PR DESCRIPTION
Hello!

We were trying to use the PCFPush SDK on a project and had some build errors. We fixed them by adding the PCFPushErrors header file to the umbrella header.

We have treat warnings as errors enabled and it's failing with: 

```
/Users/pivotal/workspace/ios/<module-includes>:1:1: Umbrella header for module 'PCFPush' does not include header 'PCFPushErrors.h'
```

Thanks!